### PR TITLE
fix: SSO redirect to walt-tab.com and add Vercel domain config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# Supabase Configuration (REQUIRED)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# Site URL - Set this to your production domain
+# Used for OAuth redirects after authentication
+VITE_SITE_URL=https://www.walt-tab.com
+
 # Google Maps API Key (for location services and geocoding)
 VITE_GOOGLE_MAPS_API_KEY=
 

--- a/docs/SUPABASE-SETUP-GUIDE.md
+++ b/docs/SUPABASE-SETUP-GUIDE.md
@@ -367,14 +367,37 @@ You should see "Success. No rows returned" - that means it worked.
 7. Copy the **Client ID** and **Client Secret**
 8. Paste them in Supabase Google provider settings
 
-### Step 3.3: Configure Auth Settings
+### Step 3.3: Configure Auth Settings (CRITICAL)
+
+⚠️ **IMPORTANT:** These settings control where users are redirected after SSO login. Incorrect settings will cause 404 errors.
 
 Go to **Authentication → URL Configuration**:
 
-- **Site URL:** Your production URL (e.g., `https://www.walt-tab.com`) or `http://localhost:5173` for dev
-- **Redirect URLs:** Add both:
+- **Site URL:** `https://www.walt-tab.com`
+  - This is the PRIMARY redirect URL after OAuth authentication
+  - **MUST be set to your production domain, NOT the Vercel URL**
+  - The app will NOT work correctly if this points to a Vercel URL
+
+- **Redirect URLs:** Add ALL of these (one per line):
   - `https://www.walt-tab.com`
+  - `https://www.walt-tab.com/`
+  - `https://www.walt-tab.com/dashboard`
   - `http://localhost:5173` (for development)
+  - `http://localhost:5173/` (for development)
+
+**Verification:** After saving, when you click "Sign in with Google", the OAuth flow should redirect back to `https://www.walt-tab.com`, NOT to any Vercel URL.
+
+### Step 3.3b: Update Google OAuth Redirect URIs
+
+If using Google Sign-In, you must also update Google Cloud Console:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com)
+2. Navigate to **APIs & Services → Credentials**
+3. Click on your OAuth 2.0 Client ID
+4. Under **Authorized redirect URIs**, ensure you have:
+   - `https://YOUR_PROJECT.supabase.co/auth/v1/callback`
+5. Under **Authorized JavaScript origins**, add:
+   - `https://www.walt-tab.com`
 
 ### Step 3.4: Configure Session Duration (2 Weeks)
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "ytt-green.vercel.app"
+        }
+      ],
+      "destination": "https://www.walt-tab.com",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "ytt-green.vercel.app"
+        }
+      ],
+      "destination": "https://www.walt-tab.com/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
- Add vercel.json with redirects from ytt-green.vercel.app to walt-tab.com
- Update AuthContext to use walt-tab.com for OAuth redirects in production
- Add VITE_SITE_URL env variable for configurable redirect URL
- Update Supabase setup docs with critical URL configuration instructions
- Add getSiteUrl() helper that prioritizes: env var > production URL > origin

The SSO 404 error was caused by Supabase redirecting to its configured Site URL (likely still pointing to Vercel). Users must update Supabase dashboard: Authentication → URL Configuration → Site URL to walt-tab.com

https://claude.ai/code/session_014sFD1bWmz3u7y2sjBN2S3s