### PR TITLE
Rebrand Walt-Tab → Valt-Tab with vault-themed dark UI

### DIFF
--- a/src/components/restaurant/DecideMode.tsx
+++ b/src/components/restaurant/DecideMode.tsx
@@ -64,6 +64,11 @@ const DecideMode: React.FC<Props> = ({ onClose }) => {
     [restaurantsList]
   );
 
+  const [filters, setFilters] = useState<Filters>(() => {
+    const saved = storageService.get<Filters>(STORAGE_KEYS.DECIDE_FILTERS);
+    return saved || DEFAULT_FILTERS;
+  });
+
   // Compute neighborhoods/cuisines scoped to the currently selected city filter
   const cityRestaurants = useMemo(
     () =>
@@ -81,11 +86,6 @@ const DecideMode: React.FC<Props> = ({ onClose }) => {
     () => [...new Set(cityRestaurants.map((r) => r.cuisine).filter(Boolean))] as string[],
     [cityRestaurants]
   );
-
-  const [filters, setFilters] = useState<Filters>(() => {
-    const saved = storageService.get<Filters>(STORAGE_KEYS.DECIDE_FILTERS);
-    return saved || DEFAULT_FILTERS;
-  });
 
   // On first open, snap city to detected location if filter hasn't been manually set
   useEffect(() => {

--- a/src/components/tools/QuickShare.tsx
+++ b/src/components/tools/QuickShare.tsx
@@ -101,13 +101,13 @@ const QuickShare: React.FC<QuickShareProps> = ({ initialUrl, onComplete }) => {
   // Google Maps entries from restaurant list
   const googleMapsEntries = useMemo(() => {
     return restaurantsList
-      .filter((r) => r.googleMapsUrl || r.googleMapsUri)
+      .filter((r) => r.googleMapsUrl || r.googleMapsUrl)
       .map((r) => ({
         id: r.id,
         name: r.name,
         cuisine: r.cuisine,
         neighborhood: r.neighborhood,
-        url: r.googleMapsUrl || r.googleMapsUri,
+        url: r.googleMapsUrl || r.googleMapsUrl,
         isNew: !r.lastVisited,
         city: r.city,
       }));
@@ -462,9 +462,9 @@ const QuickShare: React.FC<QuickShareProps> = ({ initialUrl, onComplete }) => {
                             {r.neighborhood && <span>• {r.neighborhood}</span>}
                           </div>
                         </div>
-                        {(r.googleMapsUrl || r.googleMapsUri) && (
+                        {(r.googleMapsUrl || r.googleMapsUrl) && (
                           <a
-                            href={r.googleMapsUrl || r.googleMapsUri || '#'}
+                            href={r.googleMapsUrl || r.googleMapsUrl || '#'}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="shrink-0 ml-2 px-3 py-1.5 bg-brand-ocean/10 text-brand-ocean text-xs font-semibold rounded-lg hover:bg-brand-ocean/20 transition-colors"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Global rename**: All `Walt-Tab`, `walt-tab`, `WaltTab`, `waltTab`, `walt.dash`, `Own Your Story`, `Navigate Your Life`, and domain references replaced with Valt-Tab equivalents across 38 files
- **New vault design system**: `src/styles/theme.css` with full CSS variable palette (vault-black, navy, steel, accent, gold), Sora / DM Sans / JetBrains Mono typography, and component classes (`vault-card`, `btn-primary`, `btn-ghost`, `vault-unlock` keyframe)
- **New 3-panel app shell**: sticky TopBar (56px) + collapsible Sidebar (220px ↔ 56px) + main content area replacing the old Header + Navigation
- **New components**: `VaultIcon.tsx` (SVG vault wheel), `TopBar.tsx`, `Sidebar.tsx`, `CommandPalette.tsx` (Cmd+K)
- **Dark-theme auth pages**: Login + Signup redesigned with vault CSS variables and privacy trust messaging
- **New favicon**: vault door icon on navy `#141928` background with gold center hub
- **Updated `index.html`**: new title, OG/Twitter meta, Google Font imports, `theme-color: #0D0F14`
- **Build fixes**: moved `filters` useState above dependent useMemo in `DecideMode.tsx`; corrected `googleMapsUri` → `googleMapsUrl` typo in `QuickShare.tsx`

## Test plan

- [ ] App loads with dark vault background (`#0D0F14`) and no white flash
- [ ] Sora / DM Sans / JetBrains Mono fonts load correctly
- [ ] TopBar shows Valt-Tab vault logo and search button
- [ ] Sidebar collapses/expands on ☰ toggle
- [ ] Cmd+K (or Ctrl+K) opens command palette; Escape closes it
- [ ] Sidebar nav items highlight active route correctly
- [ ] Login and Signup pages render with dark vault theme
- [ ] No instances of "Walt", "walt.dash", or old domain in visible UI text
- [ ] Vault favicon visible in browser tab
- [ ] `npm run build` exits with code 0

https://claude.ai/code/session_016WPTvcamMX3mbKXCENsqYQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WPTvcamMX3mbKXCENsqYQ)_