### PR TITLE
Fix: restore walt-tab.com as active OAuth/CORS domain

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -139,8 +139,8 @@ const analyzeCache = new ResponseCache(60 * 60 * 1000);        // 1 hour
 const allowedOrigins = [
   'http://localhost:5173',
   'http://localhost:3000',
-  'https://valt-tab.com',
-  'https://www.valt-tab.com',
+  'https://walt-tab.com',
+  'https://www.walt-tab.com',
   process.env.FRONTEND_URL,
 ].filter(Boolean);
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,12 +9,12 @@ const getSiteUrl = (): string => {
   if (import.meta.env.VITE_SITE_URL) {
     return import.meta.env.VITE_SITE_URL;
   }
-  // In production, always use the valt-tab.com domain
+  // In production, always use the walt-tab.com domain (update once DNS is switched to valt-tab.com)
   if (typeof window !== 'undefined' && !window.location.hostname.includes('localhost')) {
-    return 'https://www.valt-tab.com';
+    return 'https://www.walt-tab.com';
   }
   // For local development, use current origin
-  return typeof window !== 'undefined' ? window.location.origin : 'https://www.valt-tab.com';
+  return typeof window !== 'undefined' ? window.location.origin : 'https://www.walt-tab.com';
 };
 
 interface AuthContextType {

--- a/vercel.json
+++ b/vercel.json
@@ -36,7 +36,7 @@
           "value": "ytt-green.vercel.app"
         }
       ],
-      "destination": "https://www.valt-tab.com",
+      "destination": "https://www.walt-tab.com",
       "permanent": true
     },
     {
@@ -47,7 +47,7 @@
           "value": "ytt-green.vercel.app"
         }
       ],
-      "destination": "https://www.valt-tab.com/:path*",
+      "destination": "https://www.walt-tab.com/:path*",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary

The rebrand find-replace changed functional domain references to `valt-tab.com`, which broke Google OAuth login (redirect URL mismatch).

This reverts `walt-tab.com` in the three files that affect live functionality:

- **`src/contexts/AuthContext.tsx`** — OAuth redirect URL sent to Google
- **`vercel.json`** — Vercel canonical redirect destinations  
- **`api/server.js`** — CORS allowed origins

Visible UI branding (title, meta tags, components) remains Valt-Tab.

> When you're ready to cut over the domain to `valt-tab.com`, update these three files.

## Test plan

- [ ] Google OAuth login completes successfully
- [ ] No `redirect_uri_mismatch` error from Google
- [ ] `npm run build` exits cleanly

https://claude.ai/code/session_016WPTvcamMX3mbKXCENsqYQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016WPTvcamMX3mbKXCENsqYQ)_