### PR TITLE
Fix Google OAuth 403: remove calendar scope from sign-in

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -52,7 +52,7 @@ const SECTIONS: SectionConfig[] = [
 const SettingsPage: React.FC = () => {
   const { settings, updateSettings, setVersion, toggleApi, resetSettings } = useSettings();
   const { entries, migrateFromLocalStorage } = useEntries();
-  const { user, signOut } = useAuth();
+  const { user, signOut, linkGoogleCalendar } = useAuth();
   const { showToast } = useApp();
 
   const [activeSection, setActiveSection] = useState<SettingsSection>('general');
@@ -521,7 +521,12 @@ const SettingsPage: React.FC = () => {
                       <input
                         type="checkbox"
                         checked={settings.apis[api.key]}
-                        onChange={() => toggleApi(api.key)}
+                        onChange={() => {
+                          if (api.key === 'calendar' && !settings.apis.calendar) {
+                            linkGoogleCalendar();
+                          }
+                          toggleApi(api.key);
+                        }}
                         className="w-5 h-5 text-black rounded-sm border-2 border-black focus:ring-black"
                       />
                     </label>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -24,6 +24,7 @@ interface AuthContextType {
   signUp: (email: string, password: string) => Promise<{ error: AuthError | null }>;
   signIn: (email: string, password: string) => Promise<{ error: AuthError | null }>;
   signInWithGoogle: () => Promise<{ error: AuthError | null }>;
+  linkGoogleCalendar: () => Promise<{ error: AuthError | null }>;
   signOut: () => Promise<void>;
 }
 
@@ -76,7 +77,19 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const signInWithGoogle = async () => {
     const redirectUrl = getSiteUrl();
-    console.log('[Auth] OAuth redirect URL:', redirectUrl);
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: redirectUrl,
+      },
+    });
+    return { error };
+  };
+
+  // Request Google Calendar access separately — only called from Settings
+  // when the user explicitly enables calendar integration.
+  const linkGoogleCalendar = async () => {
+    const redirectUrl = getSiteUrl();
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
@@ -104,6 +117,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         signUp,
         signIn,
         signInWithGoogle,
+        linkGoogleCalendar,
         signOut,
       }}
     >


### PR DESCRIPTION
## Summary

Removes `calendar.readonly` from the Google sign-in OAuth request, which was causing a 403 for all users.

**Root cause:** `calendar.readonly` is a restricted Google scope. Google blocks it unless the OAuth app is fully verified by Google (or the signing-in account is explicitly listed as a test user in Google Cloud Console). It was being requested on every login attempt, blocking everyone.

**Changes:**
- `signInWithGoogle` — now uses default OpenID scopes only (email + profile), which are always permitted
- New `linkGoogleCalendar` — requests `calendar.readonly` + offline access; only called when the user explicitly enables Google Calendar in **Settings → Tools → Data Sources**

## Test plan

- [ ] "Continue with Google" on login completes without 403
- [ ] After logging in, toggling Google Calendar on in Settings triggers the calendar permission prompt
- [ ] `npm run build` exits cleanly

https://claude.ai/code/session_016WPTvcamMX3mbKXCENsqYQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016WPTvcamMX3mbKXCENsqYQ)_