### PR TITLE
Optimize layout for mobile iPhone webapp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,8 +125,20 @@ const AppContent: React.FC = () => {
 
   const navigate = useNavigate();
   const location = useLocation();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => window.innerWidth < 768);
   const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // Track mobile breakpoint
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    const handler = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+      if (e.matches) setSidebarCollapsed(true);
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
 
   // Cmd+K / Ctrl+K opens command palette
   useEffect(() => {
@@ -139,6 +151,11 @@ const AppContent: React.FC = () => {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, []);
+
+  const handleNavigate = (path: string) => {
+    navigate(path);
+    if (isMobile) setSidebarCollapsed(true);
+  };
 
   // Show loading while checking auth or loading settings from Supabase
   if (loading || settingsLoading) {
@@ -184,24 +201,39 @@ const AppContent: React.FC = () => {
     <div style={{
       display: 'flex',
       flexDirection: 'column',
-      height: '100vh',
+      height: '100dvh',
       background: 'var(--color-vault-black)',
       overflow: 'hidden',
     }}>
       <TopBar
+        isMobile={isMobile}
         onMenuToggle={() => setSidebarCollapsed(c => !c)}
         onSearchOpen={() => setPaletteOpen(true)}
       />
-      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden', position: 'relative' }}>
+        {/* Backdrop for mobile sidebar */}
+        {isMobile && !sidebarCollapsed && (
+          <div
+            onClick={() => setSidebarCollapsed(true)}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              background: 'rgba(0,0,0,0.6)',
+              zIndex: 55,
+            }}
+          />
+        )}
         <Sidebar
           collapsed={sidebarCollapsed}
+          isMobile={isMobile}
           currentPath={location.pathname}
-          onNavigate={(path) => navigate(path)}
+          onNavigate={handleNavigate}
         />
         <main style={{
           flex: 1,
           overflowY: 'auto',
-          padding: '32px 40px',
+          padding: isMobile ? '16px' : '32px 40px',
+          paddingBottom: isMobile ? 'calc(16px + env(safe-area-inset-bottom, 0px))' : '32px',
           background: 'var(--color-vault-black)',
         }}>
           <Routes>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -36,25 +36,49 @@ const NAV: NavGroup[] = [
 
 interface SidebarProps {
   collapsed: boolean;
+  isMobile?: boolean;
   currentPath: string;
   onNavigate: (path: string) => void;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ collapsed, currentPath, onNavigate }) => {
+const Sidebar: React.FC<SidebarProps> = ({ collapsed, isMobile, currentPath, onNavigate }) => {
+  // On mobile: sidebar is a fixed overlay drawer (slide in/out)
+  // On desktop: sidebar is inline and collapses to icon-only
+  const showLabels = isMobile || !collapsed;
+
+  const navStyle: React.CSSProperties = isMobile
+    ? {
+        position: 'fixed',
+        top: 'calc(56px + env(safe-area-inset-top, 0px))',
+        left: 0,
+        bottom: 0,
+        width: '260px',
+        background: 'var(--color-vault-navy)',
+        borderRight: '1px solid var(--color-vault-border)',
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        transform: collapsed ? 'translateX(-100%)' : 'translateX(0)',
+        transition: 'transform 0.25s ease',
+        zIndex: 60,
+        willChange: 'transform',
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+      }
+    : {
+        width: collapsed ? '56px' : '220px',
+        background: 'var(--color-vault-navy)',
+        borderRight: '1px solid var(--color-vault-border)',
+        height: '100%',
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        transition: 'width 0.2s ease',
+        flexShrink: 0,
+      };
+
   return (
-    <nav style={{
-      width: collapsed ? '56px' : '220px',
-      background: 'var(--color-vault-navy)',
-      borderRight: '1px solid var(--color-vault-border)',
-      height: '100%',
-      overflowY: 'auto',
-      overflowX: 'hidden',
-      transition: 'width 0.2s ease',
-      flexShrink: 0,
-    }}>
+    <nav style={navStyle}>
       {NAV.map(group => (
         <div key={group.section} style={{ marginTop: '16px' }}>
-          {!collapsed && (
+          {showLabels && (
             <div style={{
               padding: '4px 16px',
               fontSize: '10px',
@@ -72,13 +96,13 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed, currentPath, onNavigate })
               <button
                 key={item.path}
                 onClick={() => onNavigate(item.path)}
-                title={collapsed ? item.label : undefined}
+                title={!showLabels ? item.label : undefined}
                 style={{
                   width: '100%',
                   display: 'flex',
                   alignItems: 'center',
-                  gap: '10px',
-                  padding: collapsed ? '10px 16px' : '9px 16px',
+                  gap: '12px',
+                  padding: isMobile ? '14px 20px' : (collapsed ? '10px 16px' : '9px 16px'),
                   background: active ? 'rgba(79,142,247,0.1)' : 'transparent',
                   borderLeft: active ? '3px solid var(--color-vault-accent)' : '3px solid transparent',
                   border: 'none',
@@ -87,12 +111,14 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed, currentPath, onNavigate })
                   borderBottom: 'none',
                   color: active ? 'var(--color-vault-text)' : 'var(--color-vault-muted)',
                   cursor: 'pointer',
-                  fontSize: '14px',
+                  fontSize: isMobile ? '15px' : '14px',
                   fontFamily: 'var(--font-body)',
                   textAlign: 'left',
                   transition: 'background 0.1s, color 0.1s',
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',
+                  minHeight: 0,
+                  minWidth: 0,
                 }}
                 onMouseOver={e => {
                   if (!active) {
@@ -107,8 +133,8 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed, currentPath, onNavigate })
                   }
                 }}
               >
-                <span style={{ fontSize: '16px', flexShrink: 0 }}>{item.icon}</span>
-                {!collapsed && <span>{item.label}</span>}
+                <span style={{ fontSize: isMobile ? '20px' : '16px', flexShrink: 0 }}>{item.icon}</span>
+                {showLabels && <span>{item.label}</span>}
               </button>
             );
           })}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -4,109 +4,139 @@ import VaultIcon from './VaultIcon';
 interface TopBarProps {
   onMenuToggle: () => void;
   onSearchOpen: () => void;
+  isMobile?: boolean;
 }
 
-const TopBar: React.FC<TopBarProps> = ({ onMenuToggle, onSearchOpen }) => {
+const TopBar: React.FC<TopBarProps> = ({ onMenuToggle, onSearchOpen, isMobile }) => {
   return (
     <header style={{
-      height: '56px',
       background: 'var(--color-vault-navy)',
       borderBottom: '1px solid var(--color-vault-border)',
-      display: 'flex',
-      alignItems: 'center',
-      padding: '0 16px',
-      gap: '16px',
       position: 'sticky',
       top: 0,
       zIndex: 100,
       flexShrink: 0,
+      paddingTop: 'env(safe-area-inset-top, 0px)',
     }}>
-      {/* Toggle + logo */}
-      <button
-        onClick={onMenuToggle}
-        aria-label="Toggle sidebar"
-        style={{
-          background: 'none',
-          border: 'none',
-          color: 'var(--color-vault-muted)',
-          cursor: 'pointer',
-          fontSize: '20px',
-          padding: '4px',
-          lineHeight: 1,
-          flexShrink: 0,
-        }}
-      >
-        ☰
-      </button>
-
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--color-vault-gold)', flexShrink: 0 }}>
-        <VaultIcon size={24} />
-        <span style={{
-          fontFamily: 'var(--font-display)',
-          fontWeight: 700,
-          fontSize: '18px',
-          color: 'var(--color-vault-text)',
-          letterSpacing: '-0.01em',
-        }}>
-          Valt<span style={{ color: 'var(--color-vault-muted)', fontWeight: 400 }}>-tab</span>
-        </span>
-      </div>
-
-      {/* Centered search */}
-      <div style={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-        <button
-          onClick={onSearchOpen}
-          aria-label="Open command palette"
-          style={{
-            width: '40%',
-            minWidth: '200px',
-            maxWidth: '480px',
-            background: 'var(--color-vault-steel)',
-            border: '1px solid var(--color-vault-border)',
-            borderRadius: '8px',
-            padding: '8px 14px',
-            color: 'var(--color-vault-muted)',
-            fontFamily: 'var(--font-body)',
-            fontSize: '14px',
-            cursor: 'text',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            textAlign: 'left',
-            transition: 'border-color 0.15s',
-          }}
-          onMouseOver={e => (e.currentTarget.style.borderColor = 'var(--color-vault-muted)')}
-          onMouseOut={e => (e.currentTarget.style.borderColor = 'var(--color-vault-border)')}
-        >
-          <span>🔍</span>
-          <span style={{ flex: 1 }}>Search your vault...</span>
-          <span style={{
-            fontSize: '11px',
-            fontFamily: 'var(--font-mono)',
-            background: 'var(--color-vault-navy)',
-            border: '1px solid var(--color-vault-border)',
-            borderRadius: '4px',
-            padding: '1px 5px',
-          }}>⌘K</span>
-        </button>
-      </div>
-
-      {/* Avatar placeholder */}
       <div style={{
-        width: 32,
-        height: 32,
-        borderRadius: '50%',
-        background: 'var(--color-vault-accent)',
+        height: '56px',
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: '14px',
-        fontWeight: 600,
-        color: 'white',
-        cursor: 'pointer',
-        flexShrink: 0,
+        paddingLeft: '16px',
+        paddingRight: '16px',
+        gap: isMobile ? '10px' : '16px',
       }}>
-        V
+        {/* Hamburger */}
+        <button
+          onClick={onMenuToggle}
+          aria-label="Toggle sidebar"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'var(--color-vault-muted)',
+            cursor: 'pointer',
+            fontSize: '20px',
+            padding: '4px',
+            lineHeight: 1,
+            flexShrink: 0,
+            minHeight: 0,
+            minWidth: 0,
+          }}
+        >
+          ☰
+        </button>
+
+        {/* Logo */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--color-vault-gold)', flexShrink: 0 }}>
+          <VaultIcon size={22} />
+          <span style={{
+            fontFamily: 'var(--font-display)',
+            fontWeight: 700,
+            fontSize: isMobile ? '16px' : '18px',
+            color: 'var(--color-vault-text)',
+            letterSpacing: '-0.01em',
+          }}>
+            Valt<span style={{ color: 'var(--color-vault-muted)', fontWeight: 400 }}>-tab</span>
+          </span>
+        </div>
+
+        {/* Search */}
+        <div style={{ flex: 1, display: 'flex', justifyContent: isMobile ? 'flex-end' : 'center' }}>
+          {isMobile ? (
+            <button
+              onClick={onSearchOpen}
+              aria-label="Open search"
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--color-vault-muted)',
+                cursor: 'pointer',
+                fontSize: '20px',
+                padding: '4px 8px',
+                lineHeight: 1,
+                minHeight: 0,
+                minWidth: 0,
+              }}
+            >
+              🔍
+            </button>
+          ) : (
+            <button
+              onClick={onSearchOpen}
+              aria-label="Open command palette"
+              style={{
+                width: '40%',
+                minWidth: '200px',
+                maxWidth: '480px',
+                background: 'var(--color-vault-steel)',
+                border: '1px solid var(--color-vault-border)',
+                borderRadius: '8px',
+                padding: '8px 14px',
+                color: 'var(--color-vault-muted)',
+                fontFamily: 'var(--font-body)',
+                fontSize: '14px',
+                cursor: 'text',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                textAlign: 'left',
+                transition: 'border-color 0.15s',
+                minHeight: 0,
+              }}
+              onMouseOver={e => (e.currentTarget.style.borderColor = 'var(--color-vault-muted)')}
+              onMouseOut={e => (e.currentTarget.style.borderColor = 'var(--color-vault-border)')}
+            >
+              <span>🔍</span>
+              <span style={{ flex: 1 }}>Search your vault...</span>
+              <span style={{
+                fontSize: '11px',
+                fontFamily: 'var(--font-mono)',
+                background: 'var(--color-vault-navy)',
+                border: '1px solid var(--color-vault-border)',
+                borderRadius: '4px',
+                padding: '1px 5px',
+              }}>⌘K</span>
+            </button>
+          )}
+        </div>
+
+        {/* Avatar */}
+        <div style={{
+          width: 32,
+          height: 32,
+          borderRadius: '50%',
+          background: 'var(--color-vault-accent)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '14px',
+          fontWeight: 600,
+          color: 'white',
+          cursor: 'pointer',
+          flexShrink: 0,
+        }}>
+          V
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
- Sidebar now starts hidden on mobile and slides in as a drawer overlay when the hamburger is tapped; tapping the backdrop or a nav item closes it
- TopBar shows a compact icon-only search button on mobile instead of the full search bar, preventing overflow on small screens
- TopBar adds env(safe-area-inset-top) padding so content sits below the notch/Dynamic Island in standalone PWA mode
- Main content padding reduced from 32px 40px to 16px on mobile, with env(safe-area-inset-bottom) at the bottom
- App uses 100dvh instead of 100vh to correctly handle iOS Safari's dynamic viewport
- Mobile breakpoint tracked via matchMedia; navigating on mobile auto-closes the sidebar

https://claude.ai/code/session_017QNS7Abqrh8shhMhYUQ6Ti